### PR TITLE
Fix packed/unpacked struct casting warning

### DIFF
--- a/src/ubloxGPS.h
+++ b/src/ubloxGPS.h
@@ -584,7 +584,7 @@ struct ubx_mga_flash_ack_t {
     uint8_t ack; // ubx_mga_flash_ack_type_t
     uint8_t reserved1;
     uint16_t sequence; // of the message for this ACK or 0xFFFF for UBX-MGA-FLASH-STOP
-};
+} __attribute((packed));
 
 struct ubx_mon_ver_t {
     bool    valid;


### PR DESCRIPTION
### Problem
Two warnings are present when compiling ubloxGPS.cpp
```
gps-ublox/src/ubloxGPS.cpp:1892:51: warning: converting a packed 'const ubx_msg_t' pointer (alignment 1) to a 'const ubx_mga_flash_ack_t' pointer (alignment 2) may result in an unaligned pointer value [-Waddress-of-packed-member]
gps-ublox/src/ubloxGPS.cpp:1948:51: warning: converting a packed 'const ubx_msg_t' pointer (alignment 1) to a 'const ubx_mga_flash_ack_t' pointer (alignment 2) may result in an unaligned pointer value [-Waddress-of-packed-member]
```

### Solution

Both warnings are a result of casting a packed structure pointer from `const ubx_msg_t *` to unpacked `const ubx_mga_flash_ack_t *`.  The fix is simply to make `ubx_mga_flash_ack_t` also packed so that potential field misalignment won't cause bugs.
