### PR TITLE
[gen2] fix build for use of CHECK macros

### DIFF
--- a/src/ubloxGPS.cpp
+++ b/src/ubloxGPS.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "Particle.h"
+#include "check.h"
 #include "ubloxGPS.h"
 #include <mutex>
 #include <cmath>


### PR DESCRIPTION
# Problem

When including this library as a submodule for a multi-platform project, the CHECK macros fail to build on Gen2 devices since the check.h header was not included.  It is getting included only by chance for Gen3.  It's not included in Particle.h.

# Solution

`#include "check.h"`
Alternatively the CHECK macros could be copied here since this is an undocumented internal Device OS define/service.