### PR TITLE
fix: 🐛[gen2] fix build for use of scope guard

### DIFF
--- a/src/ubloxGPS.cpp
+++ b/src/ubloxGPS.cpp
@@ -15,6 +15,7 @@
  */
 #include "Particle.h"
 #include "check.h"
+#include "scope_guard.h"
 #include "ubloxGPS.h"
 #include <mutex>
 #include <cmath>


### PR DESCRIPTION
# Problem
![err](https://user-images.githubusercontent.com/71637740/165043594-3821abb3-e816-41dd-be51-26a2454c032a.png)
When including this library as a submodule for a multi-platform project, the scope guard fail to build on Gen2 devices since the `scope_guard.h` header was not included.  It is getting included only by chance for Gen3.  It's not included in Particle.h.

# Solution

`#include "scope_guard.h"`
Alternatively the scope guard could be copied here since this is an undocumented internal Device OS define/service.


The issue is the same as the issue of [CHECK macros](https://github.com/particle-iot/gps-ublox/pull/11).