### PR TITLE
feature: request and parse HNR-ATT messages to get the attitude solution (pitch/roll/heading)

### DIFF
--- a/src/ubloxGPS.h
+++ b/src/ubloxGPS.h
@@ -130,6 +130,7 @@ typedef enum {
     UBX_PUBX_SVSTATUS        = 0x03, // Satellite Status
     UBX_PUBX_TIME            = 0x04, // Time of Day and Clock information
     UBX_MGA_INI_TIME_UTC     = 0x40, // Initial Time Assistance
+    UBX_HNR_ATT              = 0x01,
     UBX_ID_INVALID           = 0xFF
 } ubx_msg_id_t;
 
@@ -403,6 +404,18 @@ struct ubx_esf_status_t {
     uint8_t faults[12];
     bool    valid;
 };
+
+struct ubx_hnr_att_t {
+    uint32_t iTOW; // ms, GPS time of week of the HNR epoch
+    uint8_t version; // version - should be 0x01
+    uint8_t reserved[3]; // reserved
+    int32_t roll; // Vehicle roll in degree. Scaled by 1e-5
+    int32_t pitch; // Vehicle pitch in degree. Scaled by 1e-5
+    int32_t heading; // Vehicle heading in degree. Scaled by 1e-5
+    uint32_t accRoll; // Roll accuracy or null if roll angle is not available.
+    uint32_t accPitch; // Roll accuracy or null if roll angle is not available.
+    uint32_t accHeading; // Roll accuracy or null if roll angle is not available.
+} __attribute__((packed));
 
 struct ubx_nav_aopstatus_t {
     uint32_t iTOW;          // ms, GPS time of week of the navigation epoch.
@@ -785,6 +798,16 @@ typedef struct {
     uint32_t tAccNs;
 } ubx_mga_init_time_utc_t;
 
+typedef struct {
+    uint32_t timeOfWeek;
+    float roll;
+    float pitch;
+    float heading;
+    float accRoll;
+    float accPitch;
+    float accHeading;
+} ubx_attitude_t;
+
 class ubloxGPS
 {
 
@@ -814,6 +837,7 @@ public:
         int tx_ready_gps_pin = PIN_INVALID);
 
     gps_t nmea_gps;
+    ubx_attitude_t attitude;
 
     /**
      * @brief Acquires the gps lock, useful for multiple gps operations at a time
@@ -1002,6 +1026,11 @@ public:
     double   getVerticalAccuracy(void);
 
     float    getDistance(double lat1, double long1, double lat2, double long2);
+
+    /**
+     * @brief Copy the latest device orientation to output variable.
+    */
+    void getAttitude(ubx_attitude_t *o);
 
     /**
      * @brief Set new baudrate for ubloxGPS UART port

--- a/src/ubloxGPS.h
+++ b/src/ubloxGPS.h
@@ -83,6 +83,7 @@ typedef enum {
     UBX_CFG_ESFA             = 0x4C, // Accelerometer sensor configuration
     UBX_CFG_ESFLA            = 0x2F, // Lever-arm configuration
     UBX_UPD_SOS              = 0x14, // System restored from backup
+    UBX_ESF_ALG              = 0x14, // Accelerometer sensor configuration
     UBX_ESF_INS              = 0x15, // Vehicle dynamics information
     UBX_ESF_MEAS             = 0x02, // External Sensor Fusion Measurements
     UBX_ESF_RAW              = 0x03, // Raw sensor measurements
@@ -398,12 +399,26 @@ struct ubx_msg_t {
 struct ubx_esf_status_t {
     uint8_t fusionMode;
     uint8_t numSens;
+    uint8_t initStatus1;
+    uint8_t initStatus2;
     uint8_t sensStatus1[12];
     uint8_t sensStatus2[12];
     uint8_t freq[12];
     uint8_t faults[12];
     bool    valid;
 };
+
+// Sensor alignment information
+struct ubx_esf_alg_t {
+    uint32_t iTOW; // ms, GPS time of week of the HNR epoch
+    uint8_t version; // version - should be 0x01
+    uint8_t flags;
+    uint8_t error;
+    uint8_t reserved1;
+    uint32_t yaw;
+    int16_t pitch;
+    int16_t roll;
+} __attribute__((packed));
 
 struct ubx_hnr_att_t {
     uint32_t iTOW; // ms, GPS time of week of the HNR epoch
@@ -1077,6 +1092,7 @@ public:
     bool  saveOnShutdown(void);
     bool  setTime(ubx_mga_init_time_utc_t timeAssist);
     bool  setMode(ubx_dynamic_model_t dynModel);
+    bool  getEsfAlignmentStatus(ubx_esf_alg_t &alg);
 
     /**
      * @brief Get the dynamic model response after the request has been sent with updateMode()
@@ -1208,6 +1224,7 @@ private:
     uint8_t gpsUnit;
     uint32_t last_receive_time;
     ubx_esf_status_t esf_status;
+    ubx_esf_alg_t esf_alg;
     ubx_nav_odo_t    nav_odo;
     ubx_nav_aopstatus_t nav_aopstatus;
     ubx_nav_sat_t nav_sat;


### PR DESCRIPTION
I wanted to get Pitch/Roll/Heading calculated by the GPS in my trackerone application. Here is a small patch to parse the HNR-ATT message from the ublox module.

Let me know what you think!